### PR TITLE
fix: allow `pnpm isntall` to work after clone. add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/node_modules
+/.idea
+/.vscode
+/.env

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
 onlyBuiltDependencies:
   - esbuild
+packages:
+  - 'packages/*'


### PR DESCRIPTION
Just some clean up on the initial setup.

Branch name was chosen before understanding repo.